### PR TITLE
Refactor and migrate Category module to use Prisma ORM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN npm ci
 
 COPY . .
 
-RUN npm run build
 RUN npx prisma generate
+RUN npm run build
 
 EXPOSE 8070
 CMD ["node", "dist/main.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
-        "@nestjs/cli": "^11.0.0",
+        "@nestjs/cli": "^11.0.10",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
         "@swc/cli": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
-    "@nestjs/cli": "^11.0.0",
+    "@nestjs/cli": "^11.0.10",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
     "@swc/cli": "^0.6.0",

--- a/prisma/migrations/20251008093731_add_category_model/migration.sql
+++ b/prisma/migrations/20251008093731_add_category_model/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "categories" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "categories_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,3 +13,10 @@ model User {
 
   @@map("users")
 }
+
+model Category {
+  id   String @id @default(uuid())
+  name String
+
+  @@map("categories")
+}

--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -1,29 +1,37 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
-import { Category } from './entities/category';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
 import { CategoryService } from './category.service';
 import { CreateCategoryDto } from './dto/create-category.dto';
+import { Category } from '@prisma/client';
 
 @Controller('category')
 export class CategoryController {
   constructor(private readonly service: CategoryService) {}
 
   @Get()
-  getAll(): Category[] {
+  async getAll(): Promise<Category[]> {
     return this.service.getAll();
   }
 
   @Get(':id')
-  getById(@Param('id') id: string): Category | string {
-    return this.service.getById(id);
+  async findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Category> {
+    return this.service.findOne(id);
   }
 
   @Post()
-  create(@Body() dto: CreateCategoryDto): Category {
+  async create(@Body() dto: CreateCategoryDto): Promise<Category> {
     return this.service.create(dto);
   }
 
   @Delete(':id')
-  deleteById(@Param('id') id: string): string {
-    return this.service.deleteById(id);
+  async delete(@Param('id', ParseUUIDPipe) id: string): Promise<Category> {
+    return this.service.delete(id);
   }
 }

--- a/src/category/category.module.ts
+++ b/src/category/category.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { CategoryService } from './category.service';
 import { CategoryController } from './category.controller';
 import { CategoryRepository } from './category.repository';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [CategoryController],
   providers: [CategoryService, CategoryRepository],
 })

--- a/src/category/category.repository.ts
+++ b/src/category/category.repository.ts
@@ -1,46 +1,26 @@
 import { Injectable } from '@nestjs/common';
-import { Category } from './entities/category';
-import { CreateCategoryDto } from './dto/create-category.dto';
+import { Prisma, Category } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class CategoryRepository {
-  private categories: Category[] = [];
+  constructor(private readonly prisma: PrismaService) {}
 
-  getAll(): Category[] {
-    return this.categories;
+  async getAll(): Promise<Category[]> {
+    return this.prisma.category.findMany();
   }
 
-  getById(id: string): Category | string {
-    const category = this.categories.find((category) => category.id == id);
-
-    if (!category) {
-      return `Category with id: ${id} not found`;
-    }
-
-    return category;
+  async findOne(
+    where: Prisma.CategoryWhereUniqueInput,
+  ): Promise<Category | null> {
+    return this.prisma.category.findUnique({ where });
   }
 
-  create(dto: CreateCategoryDto): Category {
-    const category: Category = {
-      id: this.categories.length + 1,
-      name: dto.name,
-    };
-
-    this.categories.push(category);
-
-    return category;
+  async create(data: Prisma.CategoryCreateInput): Promise<Category> {
+    return this.prisma.category.create({ data });
   }
 
-  deleteById(id: string): string {
-    const categoryIndex = this.categories.findIndex(
-      (category) => category.id == id,
-    );
-
-    if (categoryIndex !== -1) {
-      this.categories.splice(categoryIndex, 1);
-      return 'Category deleted successfully';
-    }
-
-    return `Category with id: ${id} not found`;
+  async delete(where: Prisma.CategoryWhereUniqueInput): Promise<Category> {
+    return this.prisma.category.delete({ where });
   }
 }

--- a/src/category/category.service.ts
+++ b/src/category/category.service.ts
@@ -1,25 +1,37 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CategoryRepository } from './category.repository';
-import { Category } from './entities/category';
+import { Category } from '@prisma/client';
 import { CreateCategoryDto } from './dto/create-category.dto';
 
 @Injectable()
 export class CategoryService {
   constructor(private readonly repository: CategoryRepository) {}
 
-  getAll(): Category[] {
+  async getAll(): Promise<Category[]> {
     return this.repository.getAll();
   }
 
-  getById(id: string): Category | string {
-    return this.repository.getById(id);
+  async findOne(id: string): Promise<Category> {
+    const user = await this.repository.findOne({ id });
+
+    if (!user) {
+      throw new NotFoundException(`Category with id: ${id} not found`);
+    }
+
+    return user;
   }
 
-  create(dto: CreateCategoryDto): Category {
+  async create(dto: CreateCategoryDto): Promise<Category> {
     return this.repository.create(dto);
   }
 
-  deleteById(id: string): string {
-    return this.repository.deleteById(id);
+  async delete(id: string): Promise<Category> {
+    const user = await this.repository.findOne({ id });
+
+    if (!user) {
+      throw new NotFoundException(`Category with id: ${id} not found`);
+    }
+
+    return this.repository.delete({ id });
   }
 }

--- a/src/category/dto/create-category.dto.ts
+++ b/src/category/dto/create-category.dto.ts
@@ -1,7 +1,8 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, Length } from 'class-validator';
 
 export class CreateCategoryDto {
   @IsNotEmpty()
   @IsString()
+  @Length(2, 30)
   name: string;
 }

--- a/src/category/entities/category.ts
+++ b/src/category/entities/category.ts
@@ -1,4 +1,0 @@
-export class Category {
-  id: number | string;
-  name: string;
-}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UserService } from './user.service';
 import { User } from '@prisma/client';
@@ -8,12 +16,12 @@ export class UserController {
   constructor(private readonly service: UserService) {}
 
   @Get('user/:id')
-  async findOne(@Param('id') id: string): Promise<User> {
+  async findOne(@Param('id', ParseUUIDPipe) id: string): Promise<User> {
     return this.service.findOne(id);
   }
 
   @Delete('user/:id')
-  async delete(@Param('id') id: string): Promise<User> {
+  async delete(@Param('id', ParseUUIDPipe) id: string): Promise<User> {
     return this.service.delete(id);
   }
 


### PR DESCRIPTION

- Refactored the `Category` module to use Prisma as the ORM
- Added model definition for `Category` with appropriate migration
- Implemented validation for `Category` data in the refactored module